### PR TITLE
Perf and stuff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base-x"
 description = "Encode/decode any base"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Alex R. <alexei.rudenko@gmail.com>"]
 license-file = "LICENSE.md"
 readme = "README.md"


### PR DESCRIPTION
**This PR introduces breaking changes**

This is mostly targeted towards [multibase](https://github.com/multiformats/rust-multibase/pull/3). Some of the important changes:

- API changed to accept `&[u8]` instead of `Vec<u8>` for encoding.
- Alphabet is presumed to be ASCII and is also of type `&[u8]`. 
- Encoding returns unwrapped `String`. Note: _encoding can panic_ if the alphabet is empty. This would be considered a programmer's error since we don't expect the alphabet input to come from a user. 
- Got rid of hashmaps. Decoding creates a 256-byte long lookup table on stack instead.