### PR TITLE
Generic `Alphabet` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base-x"
 description = "Encode/decode any base"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Alex R. <alexei.rudenko@gmail.com>"]
 license-file = "LICENSE.md"
 readme = "README.md"
@@ -10,4 +10,4 @@ repository = "https://github.com/OrKoN/base-x-rs"
 homepage = "https://github.com/OrKoN/base-x-rs"
 
 [dev-dependencies]
-rustc-serialize = "0.3"
+json = "0.11"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ And this my very first Rust project: please review the source code!
 
 Add this to `Cargo.toml` file:
 
-```
+```toml
 [dependencies]
 base-x = "0.2.0"
 ```
@@ -18,12 +18,10 @@ base-x = "0.2.0"
 extern crate base_x;
 
 fn main() {
-  let alphabet = "01";
-  let decoded = base_x::decode(alphabet.as_bytes(), "11111111000000001111111100000000").unwrap();
-  let encoded = base_x::encode(alphabet.as_bytes(), decoded).unwrap();
-  assert_eq!(encoded, "11111111000000001111111100000000");
+    let decoded = base_x::decode("01", "11111111000000001111111100000000").unwrap();
+    let encoded = base_x::encode("01", &decoded);
+    assert_eq!(encoded, "11111111000000001111111100000000");
 }
-
 ```
 
 ## Changelog

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,0 +1,71 @@
+pub const INVALID_INDEX: u8 = 0xFF;
+
+pub trait Alphabet {
+    fn as_bytes(&self) -> &[u8];
+
+    /// Produces the lookup table matching byte index [0 - 255] to a
+    /// corresponding alphabet byte.
+    ///
+    /// The default implementation will produce the lookup table on
+    /// runtime, and recalculate it every time encoding is invoked.
+    /// Ideally a custom implementation of the `Alphabet` would return
+    /// a `&'static` precalculated table here.
+    #[inline]
+    fn lookup_table(&self) -> [u8; 256] {
+        let mut lookup = [INVALID_INDEX; 256];
+
+        for (i, byte) in self.as_bytes().iter().enumerate() {
+            lookup[*byte as usize] = i as u8;
+        }
+
+        lookup
+    }
+
+    #[inline]
+    fn base(&self) -> usize {
+        self.as_bytes().len()
+    }
+}
+
+impl<T: AsRef<[u8]>> Alphabet for T {
+    #[inline(always)]
+    fn as_bytes(&self) -> &[u8] {
+        self.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Alphabet;
+    use super::INVALID_INDEX;
+
+    #[test]
+    fn lookup_str() {
+        let alphabet = "abcd";
+
+        let lookup = alphabet.lookup_table();
+
+        assert_eq!(lookup[b'a' as usize], 0);
+        assert_eq!(lookup[b'b' as usize], 1);
+        assert_eq!(lookup[b'c' as usize], 2);
+        assert_eq!(lookup[b'd' as usize], 3);
+        assert_eq!(lookup[b'e' as usize], INVALID_INDEX);
+        assert_eq!(lookup[b'$' as usize], INVALID_INDEX);
+        assert_eq!(lookup[b'7' as usize], INVALID_INDEX);
+    }
+
+    #[test]
+    fn lookup_bytes() {
+        let alphabet: &[u8] = &[0x13,0x37,0xDE,0xAD];
+
+        let lookup = alphabet.lookup_table();
+
+        assert_eq!(lookup[0x13], 0);
+        assert_eq!(lookup[0x37], 1);
+        assert_eq!(lookup[0xDE], 2);
+        assert_eq!(lookup[0xAD], 3);
+        assert_eq!(lookup[0x00], INVALID_INDEX);
+        assert_eq!(lookup[0x80], INVALID_INDEX);
+        assert_eq!(lookup[0xFF], INVALID_INDEX);
+    }
+}

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,7 +1,45 @@
-pub const INVALID_INDEX: u8 = 0xFF;
+use std::collections::HashMap;
+
+const INVALID_INDEX: u8 = 0xFF;
 
 pub trait Alphabet {
+    type Lookup: CharlookUp;
+
+    /// Get a character from Alphabet at index.
+    ///
+    /// This method can panic if usize doesn't fit in base.
+    fn get(&self, usize) -> char;
+
+    /// Get a byte array of the alphabet. This can be useful
+    /// for ASCII-based alphabets.
     fn as_bytes(&self) -> &[u8];
+
+    /// Returns a lookup type used to find an index of a char
+    /// in the Alphabet.
+    fn lookup_table(&self) -> Self::Lookup;
+
+    /// Get the base (length in characters) of the Alphabet.
+    fn base(&self) -> usize;
+}
+
+pub trait CharlookUp: Sized {
+    /// Get the index of the `char` in the Alphabet. If `char`
+    /// is not in the Alphabet return `None`.
+    fn get(&self, char) -> Option<usize>;
+}
+
+impl<'a> Alphabet for &'a [u8] {
+    type Lookup = [u8; 256];
+
+    #[inline]
+    fn get(&self, index: usize) -> char {
+        self[index] as char
+    }
+
+    #[inline]
+    fn as_bytes(&self) -> &[u8] {
+        *self
+    }
 
     /// Produces the lookup table matching byte index [0 - 255] to a
     /// corresponding alphabet byte.
@@ -11,7 +49,7 @@ pub trait Alphabet {
     /// Ideally a custom implementation of the `Alphabet` would return
     /// a `&'static` precalculated table here.
     #[inline]
-    fn lookup_table(&self) -> [u8; 256] {
+    fn lookup_table(&self) -> Self::Lookup {
         let mut lookup = [INVALID_INDEX; 256];
 
         for (i, byte) in self.as_bytes().iter().enumerate() {
@@ -23,49 +61,102 @@ pub trait Alphabet {
 
     #[inline]
     fn base(&self) -> usize {
-        self.as_bytes().len()
+        self.len()
     }
 }
 
-impl<T: AsRef<[u8]>> Alphabet for T {
-    #[inline(always)]
+impl<'a> Alphabet for &'a str {
+    type Lookup = HashMap<char, usize>;
+
+    #[inline]
+    fn get(&self, index: usize) -> char {
+        self.chars().nth(index).expect("Index will be % base, ergo in alphabet range; qed")
+    }
+
+    #[inline]
     fn as_bytes(&self) -> &[u8] {
         self.as_ref()
+    }
+
+    /// Produces the hashmap matching any `char` to it's index in alphabet.
+    #[inline]
+    fn lookup_table(&self) -> Self::Lookup {
+        // this is byte-length, which might or might not be enough,
+        // we might suffer a reallocation at some point.
+        let mut map = HashMap::with_capacity(self.len());
+
+        for (index, ch) in self.chars().enumerate() {
+            map.insert(ch, index);
+        }
+
+        map
+    }
+
+    #[inline]
+    fn base(&self) -> usize {
+        self.chars().count()
+    }
+}
+
+impl CharlookUp for [u8; 256] {
+    #[inline]
+    fn get(&self, byte: char) -> Option<usize> {
+        match self[byte as u8 as usize] {
+            INVALID_INDEX => None,
+            byte => Some(byte as usize)
+        }
+    }
+}
+
+impl<'a> CharlookUp for &'a [u8; 256] {
+    #[inline]
+    fn get(&self, byte: char) -> Option<usize> {
+        match self[byte as u8 as usize] {
+            INVALID_INDEX => None,
+            byte => Some(byte as usize)
+        }
+    }
+}
+
+impl CharlookUp for HashMap<char, usize> {
+    #[inline]
+    fn get(&self, ch: char) -> Option<usize> {
+        self.get(&ch).map(|index| *index)
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::Alphabet;
-    use super::INVALID_INDEX;
+    use super::{Alphabet, CharlookUp};
+    use std::collections::HashMap;
 
     #[test]
     fn lookup_str() {
         let alphabet = "abcd";
 
-        let lookup = alphabet.lookup_table();
+        let lookup: HashMap<char, usize> = alphabet.lookup_table();
 
-        assert_eq!(lookup[b'a' as usize], 0);
-        assert_eq!(lookup[b'b' as usize], 1);
-        assert_eq!(lookup[b'c' as usize], 2);
-        assert_eq!(lookup[b'd' as usize], 3);
-        assert_eq!(lookup[b'e' as usize], INVALID_INDEX);
-        assert_eq!(lookup[b'$' as usize], INVALID_INDEX);
-        assert_eq!(lookup[b'7' as usize], INVALID_INDEX);
+        assert_eq!(CharlookUp::get(&lookup, 'a'), Some(0));
+        assert_eq!(CharlookUp::get(&lookup, 'b'), Some(1));
+        assert_eq!(CharlookUp::get(&lookup, 'c'), Some(2));
+        assert_eq!(CharlookUp::get(&lookup, 'd'), Some(3));
+        assert_eq!(CharlookUp::get(&lookup, 'e'), None);
+        assert_eq!(CharlookUp::get(&lookup, '7'), None);
+        assert_eq!(CharlookUp::get(&lookup, '$'), None);
     }
 
     #[test]
     fn lookup_bytes() {
-        let alphabet: &[u8] = &[0x13,0x37,0xDE,0xAD];
+        let alphabet: &[u8] = b"qwer";
 
-        let lookup = alphabet.lookup_table();
+        let lookup: [u8; 256] = alphabet.lookup_table();
 
-        assert_eq!(lookup[0x13], 0);
-        assert_eq!(lookup[0x37], 1);
-        assert_eq!(lookup[0xDE], 2);
-        assert_eq!(lookup[0xAD], 3);
-        assert_eq!(lookup[0x00], INVALID_INDEX);
-        assert_eq!(lookup[0x80], INVALID_INDEX);
-        assert_eq!(lookup[0xFF], INVALID_INDEX);
+        assert_eq!(lookup.get('q'), Some(0));
+        assert_eq!(lookup.get('w'), Some(1));
+        assert_eq!(lookup.get('e'), Some(2));
+        assert_eq!(lookup.get('r'), Some(3));
+        assert_eq!(lookup.get('t'), None);
+        assert_eq!(lookup.get('*'), None);
+        assert_eq!(lookup.get('_'), None);
     }
 }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 const INVALID_INDEX: u8 = 0xFF;
 
 pub trait Alphabet {
-    type Lookup: CharlookUp;
+    type Lookup: CharLookup;
 
     /// Get a character from Alphabet at index.
     ///
@@ -22,7 +22,7 @@ pub trait Alphabet {
     fn base(&self) -> usize;
 }
 
-pub trait CharlookUp: Sized {
+pub trait CharLookup: Sized {
     /// Get the index of the `char` in the Alphabet. If `char`
     /// is not in the Alphabet return `None`.
     fn get(&self, char) -> Option<usize>;
@@ -98,7 +98,7 @@ impl<'a> Alphabet for &'a str {
     }
 }
 
-impl CharlookUp for [u8; 256] {
+impl CharLookup for [u8; 256] {
     #[inline]
     fn get(&self, byte: char) -> Option<usize> {
         match self[byte as u8 as usize] {
@@ -108,7 +108,7 @@ impl CharlookUp for [u8; 256] {
     }
 }
 
-impl<'a> CharlookUp for &'a [u8; 256] {
+impl<'a> CharLookup for &'a [u8; 256] {
     #[inline]
     fn get(&self, byte: char) -> Option<usize> {
         match self[byte as u8 as usize] {
@@ -118,7 +118,7 @@ impl<'a> CharlookUp for &'a [u8; 256] {
     }
 }
 
-impl CharlookUp for HashMap<char, usize> {
+impl CharLookup for HashMap<char, usize> {
     #[inline]
     fn get(&self, ch: char) -> Option<usize> {
         self.get(&ch).map(|index| *index)
@@ -127,7 +127,7 @@ impl CharlookUp for HashMap<char, usize> {
 
 #[cfg(test)]
 mod test {
-    use super::{Alphabet, CharlookUp};
+    use super::{Alphabet, CharLookup};
     use std::collections::HashMap;
 
     #[test]
@@ -136,13 +136,13 @@ mod test {
 
         let lookup: HashMap<char, usize> = alphabet.lookup_table();
 
-        assert_eq!(CharlookUp::get(&lookup, 'a'), Some(0));
-        assert_eq!(CharlookUp::get(&lookup, 'b'), Some(1));
-        assert_eq!(CharlookUp::get(&lookup, 'c'), Some(2));
-        assert_eq!(CharlookUp::get(&lookup, 'd'), Some(3));
-        assert_eq!(CharlookUp::get(&lookup, 'e'), None);
-        assert_eq!(CharlookUp::get(&lookup, '7'), None);
-        assert_eq!(CharlookUp::get(&lookup, '$'), None);
+        assert_eq!(CharLookup::get(&lookup, 'a'), Some(0));
+        assert_eq!(CharLookup::get(&lookup, 'b'), Some(1));
+        assert_eq!(CharLookup::get(&lookup, 'c'), Some(2));
+        assert_eq!(CharLookup::get(&lookup, 'd'), Some(3));
+        assert_eq!(CharLookup::get(&lookup, 'e'), None);
+        assert_eq!(CharLookup::get(&lookup, '7'), None);
+        assert_eq!(CharLookup::get(&lookup, '$'), None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 
 mod alphabet;
 
-pub use alphabet::{Alphabet, CharlookUp};
+pub use alphabet::{Alphabet, CharLookup};
 
 use std::error::Error;
 use std::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,27 @@
-/// ! # base_x
-/// !
-/// ! Encode and decode any base alphabet.
+//! # base_x
+//!
+//! Encode and decode any base alphabet.
+//!
+//! ## Installation
+//!
+//! Add this to `Cargo.toml` file:
+//!
+//! ```toml
+//! [dependencies]
+//! base-x = "0.2.0"
+//! ```
+//!
+//! ## Usage
+//!
+//! ```rust
+//! extern crate base_x;
+//!
+//! fn main() {
+//!   let decoded = base_x::decode("01", "11111111000000001111111100000000").unwrap();
+//!   let encoded = base_x::encode("01", &decoded);
+//!  assert_eq!(encoded, "11111111000000001111111100000000");
+//! }
+//! ```
 
 mod alphabet;
 


### PR DESCRIPTION
### The `Alphabet` trait :tada:

+ `encode` and `decode` now can take `&[u8]`, `&str`, ~`Vec<u8>`, `String` or anything else that implements `AsRef<[u8]>`. This change is backwards compatible.~ (edit: removed this in favor of more specialization, read comment below).
+ Lookup table generation has been removed from `decode`, it is now instead obtaining the lookup table from `Alphabet::lookup_table()`. The the trait has a default implementation that creates the table on runtime, so everything is pretty much the same, except...
+ Library consumer can now create custom alphabet types with precalculated static lookup tables :zap:.

### Bonus

+ Swapped `rustc-serialize` for my humble self's `json` for the tests, which is both faster and results in considerably less boilerplate.