### PR TITLE
More granular benches

### DIFF
--- a/benches/base.rs
+++ b/benches/base.rs
@@ -4,7 +4,7 @@ extern crate rand;
 extern crate base_x;
 
 use bencher::Bencher;
-use base_x::{encode, decode};
+use base_x::{encode, decode, Alphabet};
 
 
 fn random_input(size: usize) -> Vec<u8> {
@@ -17,31 +17,91 @@ fn random_input(size: usize) -> Vec<u8> {
     v
 }
 
-fn decode_encode(bench: &mut Bencher, alph: &'static str) {
+fn test_decode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
+    let input = random_input(100);
+    let out = encode(alph, &input);
+
+    bench.iter(|| {
+        decode(alph, &out).unwrap()
+    });
+}
+
+fn test_encode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
     let input = random_input(100);
 
     bench.iter(|| {
-        let out = encode(alph, &input);
-        decode(alph, &out).unwrap()
-    })
+        encode(alph, &input)
+    });
 }
 
 // Actual benchmarks
 
-fn base2(bench: &mut Bencher) {
+// Encode UTF-8
+fn encode_base2_utf8(bench: &mut Bencher) {
     const ALPH: &'static str = "01";
-    decode_encode(bench, ALPH);
+    test_encode(bench, ALPH);
 }
 
-fn base16(bench: &mut Bencher) {
+fn encode_base16_utf8(bench: &mut Bencher) {
     const ALPH: &'static str = "0123456789abcdef";
-    decode_encode(bench, ALPH);
+    test_encode(bench, ALPH);
 }
 
-fn base58(bench: &mut Bencher) {
+fn encode_base58_utf8(bench: &mut Bencher) {
     const ALPH: &'static str = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-    decode_encode(bench, ALPH);
+    test_encode(bench, ALPH);
 }
 
-benchmark_group!(benches, base2, base16, base58);
+// Encode ASCII
+fn encode_base2_ascii(bench: &mut Bencher) {
+    const ALPH: &'static [u8] = b"01";
+    test_encode(bench, ALPH);
+}
+
+fn encode_base16_ascii(bench: &mut Bencher) {
+    const ALPH: &'static [u8] = b"0123456789abcdef";
+    test_encode(bench, ALPH);
+}
+
+fn encode_base58_ascii(bench: &mut Bencher) {
+    const ALPH: &'static [u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    test_encode(bench, ALPH);
+}
+
+// Decode UTF-8
+fn decode_base2_utf8(bench: &mut Bencher) {
+    const ALPH: &'static str = "01";
+    test_decode(bench, ALPH);
+}
+
+fn decode_base16_utf8(bench: &mut Bencher) {
+    const ALPH: &'static str = "0123456789abcdef";
+    test_decode(bench, ALPH);
+}
+
+fn decode_base58_utf8(bench: &mut Bencher) {
+    const ALPH: &'static str = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    test_decode(bench, ALPH);
+}
+
+// Decode ASCII
+fn decode_base2_ascii(bench: &mut Bencher) {
+    const ALPH: &'static [u8] = b"01";
+    test_decode(bench, ALPH);
+}
+
+fn decode_base16_ascii(bench: &mut Bencher) {
+    const ALPH: &'static [u8] = b"0123456789abcdef";
+    test_decode(bench, ALPH);
+}
+
+fn decode_base58_ascii(bench: &mut Bencher) {
+    const ALPH: &'static [u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    test_decode(bench, ALPH);
+}
+
+benchmark_group!(benches,
+    encode_base2_ascii, encode_base2_utf8, encode_base16_ascii, encode_base16_utf8, encode_base58_ascii, encode_base58_utf8,
+    decode_base2_ascii, decode_base2_utf8, decode_base16_ascii, decode_base16_utf8, decode_base58_ascii, decode_base58_utf8
+);
 benchmark_main!(benches);

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -31,12 +31,12 @@ pub trait CharLookup: Sized {
 impl<'a> Alphabet for &'a [u8] {
     type Lookup = [u8; 256];
 
-    #[inline]
+    #[inline(always)]
     fn get(&self, index: usize) -> char {
         self[index] as char
     }
 
-    #[inline]
+    #[inline(always)]
     fn as_bytes(&self) -> &[u8] {
         *self
     }
@@ -48,7 +48,7 @@ impl<'a> Alphabet for &'a [u8] {
     /// runtime, and recalculate it every time encoding is invoked.
     /// Ideally a custom implementation of the `Alphabet` would return
     /// a `&'static` precalculated table here.
-    #[inline]
+    #[inline(always)]
     fn lookup_table(&self) -> Self::Lookup {
         let mut lookup = [INVALID_INDEX; 256];
 
@@ -59,7 +59,7 @@ impl<'a> Alphabet for &'a [u8] {
         lookup
     }
 
-    #[inline]
+    #[inline(always)]
     fn base(&self) -> usize {
         self.len()
     }
@@ -68,18 +68,18 @@ impl<'a> Alphabet for &'a [u8] {
 impl<'a> Alphabet for &'a str {
     type Lookup = HashMap<char, usize>;
 
-    #[inline]
+    #[inline(always)]
     fn get(&self, index: usize) -> char {
         self.chars().nth(index).expect("Index will be % base, ergo in alphabet range; qed")
     }
 
-    #[inline]
+    #[inline(always)]
     fn as_bytes(&self) -> &[u8] {
         self.as_ref()
     }
 
     /// Produces the hashmap matching any `char` to it's index in alphabet.
-    #[inline]
+    #[inline(always)]
     fn lookup_table(&self) -> Self::Lookup {
         // this is byte-length, which might or might not be enough,
         // we might suffer a reallocation at some point.
@@ -92,14 +92,14 @@ impl<'a> Alphabet for &'a str {
         map
     }
 
-    #[inline]
+    #[inline(always)]
     fn base(&self) -> usize {
         self.chars().count()
     }
 }
 
 impl CharLookup for [u8; 256] {
-    #[inline]
+    #[inline(always)]
     fn get(&self, byte: char) -> Option<usize> {
         match self[byte as u8 as usize] {
             INVALID_INDEX => None,
@@ -109,7 +109,7 @@ impl CharLookup for [u8; 256] {
 }
 
 impl<'a> CharLookup for &'a [u8; 256] {
-    #[inline]
+    #[inline(always)]
     fn get(&self, byte: char) -> Option<usize> {
         match self[byte as u8 as usize] {
             INVALID_INDEX => None,
@@ -119,7 +119,7 @@ impl<'a> CharLookup for &'a [u8; 256] {
 }
 
 impl CharLookup for HashMap<char, usize> {
-    #[inline]
+    #[inline(always)]
     fn get(&self, ch: char) -> Option<usize> {
         self.get(&ch).map(|index| *index)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,8 @@ pub fn decode<A: Alphabet>(alphabet: A, input: &str) -> Result<Vec<u8>, DecodeEr
     let base = alphabet.base() as u16;
     let lookup = alphabet.lookup_table();
 
-    let mut bytes: Vec<u8> = vec![0];
+    let mut bytes = Vec::with_capacity(input.len());
+    bytes.push(0u8);
 
     for c in input.chars() {
         let mut carry = lookup.get(c).ok_or(DecodeError)? as u16;


### PR DESCRIPTION
My hardware right now:

```
running 12 tests
test decode_base16_ascii ... bench:       8,154 ns/iter (+/- 557)
test decode_base16_utf8  ... bench:      11,823 ns/iter (+/- 847)
test decode_base2_ascii  ... bench:      34,088 ns/iter (+/- 2,117)
test decode_base2_utf8   ... bench:      41,839 ns/iter (+/- 8,508)
test decode_base58_ascii ... bench:       5,718 ns/iter (+/- 652)
test decode_base58_utf8  ... bench:      12,243 ns/iter (+/- 6,734)
test encode_base16_ascii ... bench:     113,570 ns/iter (+/- 9,670)
test encode_base16_utf8  ... bench:     119,846 ns/iter (+/- 7,357)
test encode_base2_ascii  ... bench:     283,567 ns/iter (+/- 7,567)
test encode_base2_utf8   ... bench:     287,204 ns/iter (+/- 9,307)
test encode_base58_ascii ... bench:      47,112 ns/iter (+/- 2,598)
test encode_base58_utf8  ... bench:      53,166 ns/iter (+/- 3,553)
```

Not the fastest, encoding is kinda slow. Forced inlining helped a bit, but not much. Will try to improve it with more specialization per Alphabet type.