### PR TITLE
Bigint encoding ⚡⚡⚡

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,6 @@ keywords = ["base-x", "base", "convert"]
 repository = "https://github.com/OrKoN/base-x-rs"
 homepage = "https://github.com/OrKoN/base-x-rs"
 
-[dependencies]
-num = "*"
-
 [dev-dependencies]
 json = "0.11"
 bencher = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ keywords = ["base-x", "base", "convert"]
 repository = "https://github.com/OrKoN/base-x-rs"
 homepage = "https://github.com/OrKoN/base-x-rs"
 
+[dependencies]
+num = "*"
+
 [dev-dependencies]
 json = "0.11"
 bencher = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "base-x"
 description = "Encode/decode any base"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Alex R. <alexei.rudenko@gmail.com>"]
 license-file = "LICENSE.md"
 readme = "README.md"

--- a/benches/base.rs
+++ b/benches/base.rs
@@ -19,7 +19,7 @@ fn random_input(size: usize) -> Vec<u8> {
 }
 
 fn test_decode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
-    let input = random_input(32);
+    let input = random_input(100);
     let out = encode(alph, &input);
 
     bench.iter(|| {
@@ -28,7 +28,7 @@ fn test_decode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
 }
 
 fn test_encode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
-    let input = random_input(32);
+    let input = random_input(100);
 
     bench.iter(|| {
         encode(alph, &input)

--- a/benches/base.rs
+++ b/benches/base.rs
@@ -4,6 +4,7 @@ extern crate rand;
 extern crate base_x;
 
 use bencher::Bencher;
+use base_x::alphabet::Binary;
 use base_x::{encode, decode, Alphabet};
 
 
@@ -18,7 +19,7 @@ fn random_input(size: usize) -> Vec<u8> {
 }
 
 fn test_decode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
-    let input = random_input(100);
+    let input = random_input(32);
     let out = encode(alph, &input);
 
     bench.iter(|| {
@@ -27,7 +28,7 @@ fn test_decode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
 }
 
 fn test_encode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
-    let input = random_input(100);
+    let input = random_input(32);
 
     bench.iter(|| {
         encode(alph, &input)
@@ -35,6 +36,10 @@ fn test_encode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
 }
 
 // Actual benchmarks
+
+fn encode_base2_spec(bench: &mut Bencher) {
+    test_encode(bench, Binary);
+}
 
 // Encode UTF-8
 fn encode_base2_utf8(bench: &mut Bencher) {
@@ -101,7 +106,10 @@ fn decode_base58_ascii(bench: &mut Bencher) {
 }
 
 benchmark_group!(benches,
-    encode_base2_ascii, encode_base2_utf8, encode_base16_ascii, encode_base16_utf8, encode_base58_ascii, encode_base58_utf8,
-    decode_base2_ascii, decode_base2_utf8, decode_base16_ascii, decode_base16_utf8, decode_base58_ascii, decode_base58_utf8
+    encode_base2_spec,
+    encode_base2_ascii, encode_base2_utf8, encode_base16_ascii,
+    decode_base2_ascii, decode_base2_utf8, decode_base16_ascii,
+    encode_base16_utf8, encode_base58_ascii, encode_base58_utf8,
+    decode_base16_utf8, decode_base58_ascii, decode_base58_utf8
 );
 benchmark_main!(benches);

--- a/benches/base.rs
+++ b/benches/base.rs
@@ -18,7 +18,7 @@ fn random_input(size: usize) -> Vec<u8> {
 }
 
 fn test_decode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
-    let input = random_input(32);
+    let input = random_input(100);
     let out = encode(alph, &input);
 
     bench.iter(|| {
@@ -27,7 +27,7 @@ fn test_decode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
 }
 
 fn test_encode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
-    let input = random_input(32);
+    let input = random_input(100);
 
     bench.iter(|| {
         encode(alph, &input)

--- a/benches/base.rs
+++ b/benches/base.rs
@@ -4,7 +4,6 @@ extern crate rand;
 extern crate base_x;
 
 use bencher::Bencher;
-use base_x::alphabet::Binary;
 use base_x::{encode, decode, Alphabet};
 
 
@@ -36,10 +35,6 @@ fn test_encode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
 }
 
 // Actual benchmarks
-
-fn encode_base2_spec(bench: &mut Bencher) {
-    test_encode(bench, Binary);
-}
 
 // Encode UTF-8
 fn encode_base2_utf8(bench: &mut Bencher) {
@@ -106,7 +101,6 @@ fn decode_base58_ascii(bench: &mut Bencher) {
 }
 
 benchmark_group!(benches,
-    encode_base2_spec,
     encode_base2_ascii, encode_base2_utf8, encode_base16_ascii,
     decode_base2_ascii, decode_base2_utf8, decode_base16_ascii,
     encode_base16_utf8, encode_base58_ascii, encode_base58_utf8,

--- a/benches/base.rs
+++ b/benches/base.rs
@@ -18,7 +18,7 @@ fn random_input(size: usize) -> Vec<u8> {
 }
 
 fn test_decode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
-    let input = random_input(100);
+    let input = random_input(32);
     let out = encode(alph, &input);
 
     bench.iter(|| {
@@ -27,7 +27,7 @@ fn test_decode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
 }
 
 fn test_encode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
-    let input = random_input(100);
+    let input = random_input(32);
 
     bench.iter(|| {
         encode(alph, &input)

--- a/benches/base.rs
+++ b/benches/base.rs
@@ -37,73 +37,40 @@ fn test_encode<A: Alphabet + Copy>(bench: &mut Bencher, alph: A) {
 // Actual benchmarks
 
 // Encode UTF-8
-fn encode_base2_utf8(bench: &mut Bencher) {
+fn encode_base2(bench: &mut Bencher) {
     const ALPH: &'static str = "01";
     test_encode(bench, ALPH);
 }
 
-fn encode_base16_utf8(bench: &mut Bencher) {
+fn encode_base16(bench: &mut Bencher) {
     const ALPH: &'static str = "0123456789abcdef";
     test_encode(bench, ALPH);
 }
 
-fn encode_base58_utf8(bench: &mut Bencher) {
+fn encode_base58(bench: &mut Bencher) {
     const ALPH: &'static str = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-    test_encode(bench, ALPH);
-}
-
-// Encode ASCII
-fn encode_base2_ascii(bench: &mut Bencher) {
-    const ALPH: &'static [u8] = b"01";
-    test_encode(bench, ALPH);
-}
-
-fn encode_base16_ascii(bench: &mut Bencher) {
-    const ALPH: &'static [u8] = b"0123456789abcdef";
-    test_encode(bench, ALPH);
-}
-
-fn encode_base58_ascii(bench: &mut Bencher) {
-    const ALPH: &'static [u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
     test_encode(bench, ALPH);
 }
 
 // Decode UTF-8
-fn decode_base2_utf8(bench: &mut Bencher) {
+fn decode_base2(bench: &mut Bencher) {
     const ALPH: &'static str = "01";
     test_decode(bench, ALPH);
 }
 
-fn decode_base16_utf8(bench: &mut Bencher) {
+fn decode_base16(bench: &mut Bencher) {
     const ALPH: &'static str = "0123456789abcdef";
     test_decode(bench, ALPH);
 }
 
-fn decode_base58_utf8(bench: &mut Bencher) {
+fn decode_base58(bench: &mut Bencher) {
     const ALPH: &'static str = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
     test_decode(bench, ALPH);
 }
 
-// Decode ASCII
-fn decode_base2_ascii(bench: &mut Bencher) {
-    const ALPH: &'static [u8] = b"01";
-    test_decode(bench, ALPH);
-}
-
-fn decode_base16_ascii(bench: &mut Bencher) {
-    const ALPH: &'static [u8] = b"0123456789abcdef";
-    test_decode(bench, ALPH);
-}
-
-fn decode_base58_ascii(bench: &mut Bencher) {
-    const ALPH: &'static [u8] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-    test_decode(bench, ALPH);
-}
-
 benchmark_group!(benches,
-    encode_base2_ascii, encode_base2_utf8, encode_base16_ascii,
-    decode_base2_ascii, decode_base2_utf8, decode_base16_ascii,
-    encode_base16_utf8, encode_base58_ascii, encode_base58_utf8,
-    decode_base16_utf8, decode_base58_ascii, decode_base58_utf8
+    encode_base2, decode_base2,
+    encode_base16, decode_base16,
+    encode_base58, decode_base58
 );
 benchmark_main!(benches);

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,37 +1,22 @@
 use std::collections::HashMap;
 
 use encoder::{AsciiEncoder, Utf8Encoder};
+use decoder::{AsciiDecoder, Utf8Decoder};
+
+use DecodeError;
 
 const INVALID_INDEX: u8 = 0xFF;
 
 pub trait Alphabet {
-    type Lookup: CharLookup;
-
     fn encode(&self, input: &[u8]) -> String;
 
-    /// Get a character from Alphabet at index.
-    ///
-    /// This method can panic if usize doesn't fit in base.
-    fn get(&self, usize) -> char;
-
-    /// Get a byte array of the alphabet. This can be useful
-    /// for ASCII-based alphabets.
-    fn as_bytes(&self) -> &[u8];
-
-    /// Returns a lookup type used to find an index of a char
-    /// in the Alphabet.
-    fn lookup_table(&self) -> Self::Lookup;
-
-    /// Get the base (length in characters) of the Alphabet.
-    fn base(&self) -> usize;
+    fn decode(&self, input: &str) -> Result<Vec<u8>, DecodeError>;
 }
 
 #[derive(Clone, Copy)]
 pub struct Binary;
 
 impl Alphabet for Binary {
-    type Lookup = [u8; 256];
-
     #[inline(always)]
     fn encode(&self, input: &[u8]) -> String {
         let cap = input.len() * 8;
@@ -60,83 +45,30 @@ impl Alphabet for Binary {
     }
 
     #[inline(always)]
-    fn get(&self, index: usize) -> char {
-        index as u8 as char
+    fn decode(&self, _input: &str) -> Result<Vec<u8>, DecodeError> {
+        Ok(Vec::new())
     }
-
-    #[inline(always)]
-    fn as_bytes(&self) -> &[u8] {
-        b"01"
-    }
-
-    #[inline(always)]
-    fn lookup_table(&self) -> Self::Lookup {
-        let mut lookup = [INVALID_INDEX; 256];
-
-        for (i, byte) in self.as_bytes().iter().enumerate() {
-            lookup[*byte as usize] = i as u8;
-        }
-
-        lookup
-    }
-
-    #[inline(always)]
-    fn base(&self) -> usize {
-        2
-    }
-}
-
-pub trait CharLookup: Sized {
-    /// Get the index of the `char` in the Alphabet. If `char`
-    /// is not in the Alphabet return `None`.
-    fn get(&self, char) -> Option<usize>;
 }
 
 impl<'a> Alphabet for &'a [u8] {
-    type Lookup = [u8; 256];
-
     #[inline(always)]
     fn encode(&self, input: &[u8]) -> String {
         AsciiEncoder::encode(*self, input)
     }
 
     #[inline(always)]
-    fn get(&self, index: usize) -> char {
-        self[index] as char
-    }
-
-    #[inline(always)]
-    fn as_bytes(&self) -> &[u8] {
-        *self
-    }
-
-    /// Produces the lookup table matching byte index [0 - 255] to a
-    /// corresponding alphabet byte.
-    ///
-    /// The default implementation will produce the lookup table on
-    /// runtime, and recalculate it every time encoding is invoked.
-    /// Ideally a custom implementation of the `Alphabet` would return
-    /// a `&'static` precalculated table here.
-    #[inline(always)]
-    fn lookup_table(&self) -> Self::Lookup {
+    fn decode(&self, input: &str) -> Result<Vec<u8>, DecodeError> {
         let mut lookup = [INVALID_INDEX; 256];
 
-        for (i, byte) in self.as_bytes().iter().enumerate() {
+        for (i, byte) in self.iter().enumerate() {
             lookup[*byte as usize] = i as u8;
         }
 
-        lookup
-    }
-
-    #[inline(always)]
-    fn base(&self) -> usize {
-        self.len()
+        AsciiDecoder::decode(*self, lookup, input)
     }
 }
 
 impl<'a> Alphabet for &'a str {
-    type Lookup = HashMap<char, usize>;
-
     #[inline(always)]
     fn encode(&self, input: &[u8]) -> String {
         let alphabet: Vec<char> = self.chars().collect();
@@ -144,94 +76,51 @@ impl<'a> Alphabet for &'a str {
     }
 
     #[inline(always)]
-    fn get(&self, index: usize) -> char {
-        self.chars().nth(index).expect("Index will be % base, ergo in alphabet range; qed")
-    }
+    fn decode(&self, input: &str) -> Result<Vec<u8>, DecodeError> {
+        let alphabet: Vec<char> = self.chars().collect();
 
-    #[inline(always)]
-    fn as_bytes(&self) -> &[u8] {
-        self.as_ref()
-    }
-
-    /// Produces the hashmap matching any `char` to it's index in alphabet.
-    #[inline(always)]
-    fn lookup_table(&self) -> Self::Lookup {
-        // this is byte-length, which might or might not be enough,
-        // we might suffer a reallocation at some point.
-        let mut map = HashMap::with_capacity(self.len());
+        let mut map = HashMap::with_capacity(alphabet.len());
 
         for (index, ch) in self.chars().enumerate() {
             map.insert(ch, index);
         }
 
-        map
-    }
-
-    #[inline(always)]
-    fn base(&self) -> usize {
-        self.chars().count()
+        Utf8Decoder::decode(&alphabet, map, input)
     }
 }
 
-impl CharLookup for [u8; 256] {
-    #[inline(always)]
-    fn get(&self, byte: char) -> Option<usize> {
-        match self[byte as u8 as usize] {
-            INVALID_INDEX => None,
-            byte => Some(byte as usize)
-        }
-    }
-}
+// #[cfg(test)]
+// mod test {
+//     use super::{Alphabet, CharLookup};
+//     use std::collections::HashMap;
 
-impl<'a> CharLookup for &'a [u8; 256] {
-    #[inline(always)]
-    fn get(&self, byte: char) -> Option<usize> {
-        match self[byte as u8 as usize] {
-            INVALID_INDEX => None,
-            byte => Some(byte as usize)
-        }
-    }
-}
+//     #[test]
+//     fn lookup_str() {
+//         let alphabet = "abcd";
 
-impl CharLookup for HashMap<char, usize> {
-    #[inline(always)]
-    fn get(&self, ch: char) -> Option<usize> {
-        self.get(&ch).map(|index| *index)
-    }
-}
+//         let lookup: HashMap<char, usize> = alphabet.lookup_table();
 
-#[cfg(test)]
-mod test {
-    use super::{Alphabet, CharLookup};
-    use std::collections::HashMap;
+//         assert_eq!(CharLookup::get(&lookup, 'a'), Some(0));
+//         assert_eq!(CharLookup::get(&lookup, 'b'), Some(1));
+//         assert_eq!(CharLookup::get(&lookup, 'c'), Some(2));
+//         assert_eq!(CharLookup::get(&lookup, 'd'), Some(3));
+//         assert_eq!(CharLookup::get(&lookup, 'e'), None);
+//         assert_eq!(CharLookup::get(&lookup, '7'), None);
+//         assert_eq!(CharLookup::get(&lookup, '$'), None);
+//     }
 
-    #[test]
-    fn lookup_str() {
-        let alphabet = "abcd";
+//     #[test]
+//     fn lookup_bytes() {
+//         let alphabet: &[u8] = b"qwer";
 
-        let lookup: HashMap<char, usize> = alphabet.lookup_table();
+//         let lookup: [u8; 256] = alphabet.lookup_table();
 
-        assert_eq!(CharLookup::get(&lookup, 'a'), Some(0));
-        assert_eq!(CharLookup::get(&lookup, 'b'), Some(1));
-        assert_eq!(CharLookup::get(&lookup, 'c'), Some(2));
-        assert_eq!(CharLookup::get(&lookup, 'd'), Some(3));
-        assert_eq!(CharLookup::get(&lookup, 'e'), None);
-        assert_eq!(CharLookup::get(&lookup, '7'), None);
-        assert_eq!(CharLookup::get(&lookup, '$'), None);
-    }
-
-    #[test]
-    fn lookup_bytes() {
-        let alphabet: &[u8] = b"qwer";
-
-        let lookup: [u8; 256] = alphabet.lookup_table();
-
-        assert_eq!(lookup.get('q'), Some(0));
-        assert_eq!(lookup.get('w'), Some(1));
-        assert_eq!(lookup.get('e'), Some(2));
-        assert_eq!(lookup.get('r'), Some(3));
-        assert_eq!(lookup.get('t'), None);
-        assert_eq!(lookup.get('*'), None);
-        assert_eq!(lookup.get('_'), None);
-    }
-}
+//         assert_eq!(lookup.get('q'), Some(0));
+//         assert_eq!(lookup.get('w'), Some(1));
+//         assert_eq!(lookup.get('e'), Some(2));
+//         assert_eq!(lookup.get('r'), Some(3));
+//         assert_eq!(lookup.get('t'), None);
+//         assert_eq!(lookup.get('*'), None);
+//         assert_eq!(lookup.get('_'), None);
+//     }
+// }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -88,39 +88,3 @@ impl<'a> Alphabet for &'a str {
         Utf8Decoder::decode(&alphabet, map, input)
     }
 }
-
-// #[cfg(test)]
-// mod test {
-//     use super::{Alphabet, CharLookup};
-//     use std::collections::HashMap;
-
-//     #[test]
-//     fn lookup_str() {
-//         let alphabet = "abcd";
-
-//         let lookup: HashMap<char, usize> = alphabet.lookup_table();
-
-//         assert_eq!(CharLookup::get(&lookup, 'a'), Some(0));
-//         assert_eq!(CharLookup::get(&lookup, 'b'), Some(1));
-//         assert_eq!(CharLookup::get(&lookup, 'c'), Some(2));
-//         assert_eq!(CharLookup::get(&lookup, 'd'), Some(3));
-//         assert_eq!(CharLookup::get(&lookup, 'e'), None);
-//         assert_eq!(CharLookup::get(&lookup, '7'), None);
-//         assert_eq!(CharLookup::get(&lookup, '$'), None);
-//     }
-
-//     #[test]
-//     fn lookup_bytes() {
-//         let alphabet: &[u8] = b"qwer";
-
-//         let lookup: [u8; 256] = alphabet.lookup_table();
-
-//         assert_eq!(lookup.get('q'), Some(0));
-//         assert_eq!(lookup.get('w'), Some(1));
-//         assert_eq!(lookup.get('e'), Some(2));
-//         assert_eq!(lookup.get('r'), Some(3));
-//         assert_eq!(lookup.get('t'), None);
-//         assert_eq!(lookup.get('*'), None);
-//         assert_eq!(lookup.get('_'), None);
-//     }
-// }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,9 +1,13 @@
 use std::collections::HashMap;
 
+use encoder::{AsciiEncoder, Utf8Encoder};
+
 const INVALID_INDEX: u8 = 0xFF;
 
 pub trait Alphabet {
     type Lookup: CharLookup;
+
+    fn encode(&self, input: &[u8]) -> String;
 
     /// Get a character from Alphabet at index.
     ///
@@ -30,6 +34,11 @@ pub trait CharLookup: Sized {
 
 impl<'a> Alphabet for &'a [u8] {
     type Lookup = [u8; 256];
+
+    #[inline(always)]
+    fn encode(&self, input: &[u8]) -> String {
+        AsciiEncoder::encode(*self, input)
+    }
 
     #[inline(always)]
     fn get(&self, index: usize) -> char {
@@ -67,6 +76,12 @@ impl<'a> Alphabet for &'a [u8] {
 
 impl<'a> Alphabet for &'a str {
     type Lookup = HashMap<char, usize>;
+
+    #[inline(always)]
+    fn encode(&self, input: &[u8]) -> String {
+        let alphabet: Vec<char> = self.chars().collect();
+        Utf8Encoder::encode(&alphabet, input)
+    }
 
     #[inline(always)]
     fn get(&self, index: usize) -> char {

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -26,6 +26,66 @@ pub trait Alphabet {
     fn base(&self) -> usize;
 }
 
+#[derive(Clone, Copy)]
+pub struct Binary;
+
+impl Alphabet for Binary {
+    type Lookup = [u8; 256];
+
+    #[inline(always)]
+    fn encode(&self, input: &[u8]) -> String {
+        let cap = input.len() * 8;
+        let mut out = Vec::with_capacity(cap);
+
+        unsafe {
+            out.set_len(cap);
+
+            let ptr = out.as_mut_ptr();
+            let mut i = 0isize;
+
+            for byte in input {
+                *ptr.offset(i)     = (*byte >> 7) + 0x30;
+                *ptr.offset(i + 1) = ((*byte >> 6) & 1) + 0x30;
+                *ptr.offset(i + 2) = ((*byte >> 5) & 1) + 0x30;
+                *ptr.offset(i + 3) = ((*byte >> 4) & 1) + 0x30;
+                *ptr.offset(i + 4) = ((*byte >> 3) & 1) + 0x30;
+                *ptr.offset(i + 5) = ((*byte >> 2) & 1) + 0x30;
+                *ptr.offset(i + 6) = ((*byte >> 1) & 1) + 0x30;
+                *ptr.offset(i + 7) = (*byte & 1) + 0x30;
+                i += 8;
+            }
+
+            String::from_utf8_unchecked(out)
+        }
+    }
+
+    #[inline(always)]
+    fn get(&self, index: usize) -> char {
+        index as u8 as char
+    }
+
+    #[inline(always)]
+    fn as_bytes(&self) -> &[u8] {
+        b"01"
+    }
+
+    #[inline(always)]
+    fn lookup_table(&self) -> Self::Lookup {
+        let mut lookup = [INVALID_INDEX; 256];
+
+        for (i, byte) in self.as_bytes().iter().enumerate() {
+            lookup[*byte as usize] = i as u8;
+        }
+
+        lookup
+    }
+
+    #[inline(always)]
+    fn base(&self) -> usize {
+        2
+    }
+}
+
 pub trait CharLookup: Sized {
     /// Get the index of the `char` in the Alphabet. If `char`
     /// is not in the Alphabet return `None`.

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use encoder::{AsciiEncoder, Utf8Encoder};
 use decoder::{AsciiDecoder, Utf8Decoder};
 
@@ -11,43 +9,6 @@ pub trait Alphabet {
     fn encode(&self, input: &[u8]) -> String;
 
     fn decode(&self, input: &str) -> Result<Vec<u8>, DecodeError>;
-}
-
-#[derive(Clone, Copy)]
-pub struct Binary;
-
-impl Alphabet for Binary {
-    #[inline(always)]
-    fn encode(&self, input: &[u8]) -> String {
-        let cap = input.len() * 8;
-        let mut out = Vec::with_capacity(cap);
-
-        unsafe {
-            out.set_len(cap);
-
-            let ptr = out.as_mut_ptr();
-            let mut i = 0isize;
-
-            for byte in input {
-                *ptr.offset(i)     = (*byte >> 7) + 0x30;
-                *ptr.offset(i + 1) = ((*byte >> 6) & 1) + 0x30;
-                *ptr.offset(i + 2) = ((*byte >> 5) & 1) + 0x30;
-                *ptr.offset(i + 3) = ((*byte >> 4) & 1) + 0x30;
-                *ptr.offset(i + 4) = ((*byte >> 3) & 1) + 0x30;
-                *ptr.offset(i + 5) = ((*byte >> 2) & 1) + 0x30;
-                *ptr.offset(i + 6) = ((*byte >> 1) & 1) + 0x30;
-                *ptr.offset(i + 7) = (*byte & 1) + 0x30;
-                i += 8;
-            }
-
-            String::from_utf8_unchecked(out)
-        }
-    }
-
-    #[inline(always)]
-    fn decode(&self, _input: &str) -> Result<Vec<u8>, DecodeError> {
-        Ok(Vec::new())
-    }
 }
 
 impl<'a> Alphabet for &'a [u8] {
@@ -79,12 +40,6 @@ impl<'a> Alphabet for &'a str {
     fn decode(&self, input: &str) -> Result<Vec<u8>, DecodeError> {
         let alphabet: Vec<char> = self.chars().collect();
 
-        let mut map = HashMap::with_capacity(alphabet.len());
-
-        for (index, ch) in self.chars().enumerate() {
-            map.insert(ch, index);
-        }
-
-        Utf8Decoder::decode(&alphabet, map, input)
+        Utf8Decoder::decode(&alphabet, input)
     }
 }

--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -1,7 +1,8 @@
 use encoder::{AsciiEncoder, Utf8Encoder};
 use decoder::{AsciiDecoder, Utf8Decoder};
-
 use DecodeError;
+
+use std::ascii::AsciiExt;
 
 const INVALID_INDEX: u8 = 0xFF;
 
@@ -32,14 +33,21 @@ impl<'a> Alphabet for &'a [u8] {
 impl<'a> Alphabet for &'a str {
     #[inline(always)]
     fn encode(&self, input: &[u8]) -> String {
+        if self.is_ascii() {
+            return self.as_bytes().encode(input);
+        }
+
         let alphabet: Vec<char> = self.chars().collect();
         Utf8Encoder::encode(&alphabet, input)
     }
 
     #[inline(always)]
     fn decode(&self, input: &str) -> Result<Vec<u8>, DecodeError> {
-        let alphabet: Vec<char> = self.chars().collect();
+        if self.is_ascii() {
+            return self.as_bytes().decode(input);
+        }
 
+        let alphabet: Vec<char> = self.chars().collect();
         Utf8Decoder::decode(&alphabet, input)
     }
 }

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -20,10 +20,21 @@ impl BigUint {
     pub fn rem_div(&mut self, divider: u32) -> u32 {
         let mut carry = 0u64;
 
+        let mut pop = 0;
+
         for chunk in self.chunks.iter_mut() {
             carry = (carry << 32) | *chunk as u64;
             *chunk = (carry / divider as u64) as u32;
             carry %= divider as u64;
+
+            if *chunk == 0 {
+                pop += 1;
+            }
+        }
+
+        // TODO: Do this without a loop (might need unsafe)
+        for _ in 0..pop {
+            self.chunks.remove(0);
         }
 
         carry as u32

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1,0 +1,153 @@
+use std::{ops, mem, ptr, u32};
+
+const MASK_BASE: u32 = 0xFFFFFFFF;
+
+pub struct BigUint {
+    pub chunks: Vec<u32>
+}
+
+impl ops::ShrAssign<u8> for BigUint {
+    #[inline(always)]
+    fn shr_assign(&mut self, shift: u8) {
+        let mut carry = 0u32;
+        let unshift = 32 - shift;
+        let mask = MASK_BASE >> unshift;
+
+        for chunk in self.chunks.iter_mut() {
+            let new_carry = (*chunk & mask) << unshift;
+            *chunk >>= shift;
+            *chunk |= carry;
+            carry = new_carry;
+        }
+    }
+}
+
+impl ops::DivAssign<u32> for BigUint {
+    #[inline(always)]
+    fn div_assign(&mut self, divider: u32) {
+        let mut carry = 0u64;
+
+        for chunk in self.chunks.iter_mut() {
+            carry |= *chunk as u64;
+            *chunk = (carry / divider as u64) as u32;
+            carry = (carry % divider as u64) << 32;
+        }
+    }
+}
+
+impl BigUint {
+    #[inline(always)]
+    pub fn rem(&self, divider: u32) -> u32 {
+        self.chunks.last().unwrap() % divider
+    }
+
+    #[inline(always)]
+    pub fn is_zero(&self) -> bool {
+        self.chunks.iter().all(|chunk| *chunk == 0)
+    }
+}
+
+#[inline(always)]
+fn bytes_to_u32(bytes: [u8; 4]) -> u32 {
+    u32::from_be(unsafe { mem::transmute(bytes) })
+}
+
+#[inline(always)]
+fn slice_to_u32(slice: &[u8]) -> u32 {
+    debug_assert!(slice.len() == 4);
+
+    unsafe {
+        let mut bytes: [u8; 4] = mem::uninitialized();
+
+        ptr::copy_nonoverlapping(
+            slice.as_ptr(),
+            bytes.as_mut_ptr(),
+            4
+        );
+
+        bytes_to_u32(bytes)
+    }
+}
+
+impl<'a> From<&'a [u8]> for BigUint {
+    #[inline]
+    fn from(mut bytes: &[u8]) -> Self {
+        let modulo = bytes.len() % 4;
+
+        let mut chunks = Vec::new();
+
+        if modulo > 0 {
+            chunks.reserve(bytes.len() / 4 + 1);
+
+            let mut first = [0u8; 4];
+
+            for (r, w) in bytes[..modulo].iter().zip(first[4-modulo..].iter_mut()) {
+                *w = *r;
+            }
+
+            bytes = &bytes[modulo..];
+
+            chunks.push(bytes_to_u32(first));
+        } else {
+            chunks.reserve(bytes.len() / 4);
+        }
+
+        for slice in bytes.chunks(4) {
+            chunks.push(slice_to_u32(slice))
+        }
+
+        BigUint {
+            chunks: chunks
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BigUint;
+
+    #[test]
+    fn big_uint_from_bytes() {
+        let bytes: &[u8] = &[
+                      0xDE,0xAD,0x00,0x00,0x00,0x13,
+            0x37,0xAD,0x00,0x00,0x00,0x00,0xDE,0xAD,
+        ];
+
+        let big = BigUint::from(bytes);
+
+        assert_eq!(big.chunks, vec![0x0000DEAD, 0x00000013, 0x37AD0000, 0x0000DEAD]);
+    }
+
+    #[test]
+    fn big_uint_shr() {
+        let mut big = BigUint {
+            chunks: vec![0x0000DEAD,0x00000013, 0x37AD0000, 0x0000DEAD]
+        };
+
+        big >>= 8;
+
+        assert_eq!(big.chunks, vec![0x000000DE, 0xAD000000, 0x1337AD00, 0x000000DE]);
+    }
+
+    #[test]
+    fn big_uint_rem() {
+        let big = BigUint {
+            chunks: vec![1337]
+        };
+
+        assert_eq!(big.rem(100), 37);
+    }
+
+    #[test]
+    fn big_uint_div() {
+        let mut big = BigUint {
+            chunks: vec![0x136AD712,0x84322759]
+        };
+
+        big /= 58;
+
+        let merged = ((big.chunks[0] as u64) << 32) | big.chunks[1] as u64;
+
+        assert_eq!(merged, 0x136AD71284322759 / 58);
+    }
+}

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -46,20 +46,32 @@ macro_rules! decode {
 impl AsciiDecoder {
     #[inline(always)]
     pub fn decode(alphabet: &[u8], lookup: [u8; 256], input: &str) -> Result<Vec<u8>, DecodeError> {
-        decode!(alphabet, input, bytes, c => match lookup[c as usize] {
-            0xFF => return Err(DecodeError),
-            index => index
-        })
+        decode!(
+            alphabet,
+            input,
+            bytes,
+            c => match lookup[c as usize] {
+                0xFF => return Err(DecodeError),
+                index => index
+            }
+        )
     }
 }
 
 impl Utf8Decoder {
     #[inline(always)]
     pub fn decode(alphabet: &[char], input: &str) -> Result<Vec<u8>, DecodeError> {
-        decode!(alphabet, input, chars, c => alphabet.iter()
-                                                    .enumerate()
-                                                    .find(|&(_, ch)| *ch == c)
-                                                    .map(|(i, _)| i)
-                                                    .ok_or(DecodeError)?)
+        decode!(
+            alphabet,
+            input,
+            chars,
+            // Vector find is faster than HashMap even for Base58
+            c => alphabet
+                .iter()
+                .enumerate()
+                .find(|&(_, ch)| *ch == c)
+                .map(|(i, _)| i)
+                .ok_or(DecodeError)?
+        )
     }
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,4 +1,5 @@
 use DecodeError;
+use bigint::BigUint;
 
 pub struct AsciiDecoder;
 pub struct Utf8Decoder;
@@ -9,36 +10,27 @@ macro_rules! decode {
             return Ok(Vec::new());
         }
 
-        let base = $alpha.len() as u16;
+        let base = $alpha.len() as u32;
 
-        let mut bytes = Vec::with_capacity($input.len());
-        bytes.push(0u8);
+        let mut big = BigUint::with_capacity(4);
 
         for $c in $input.$iter() {
-            let mut carry = $carry as u16;
-
-            for byte in bytes.iter_mut() {
-                carry += base * *byte as u16;
-                *byte = carry as u8;
-                carry >>= 8;
-            }
-
-            while carry > 0 {
-                bytes.push(carry as u8);
-                carry >>= 8;
-            }
+            big.add_mul($carry as u32, base);
         }
+
+        let mut bytes = big.into_bytes_be();
 
         let leader = $alpha[0];
 
         let leaders = $input
             .$iter()
-            .take($input.len() - 1)
             .take_while(|byte| *byte == leader)
-            .map(|_| 0);
+            .count();
 
-        bytes.extend(leaders);
-        bytes.reverse();
+        for _ in 0..leaders {
+            bytes.insert(0, 0);
+        }
+
         Ok(bytes)
     })
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+
+use DecodeError;
+
+pub struct AsciiDecoder;
+pub struct Utf8Decoder;
+
+macro_rules! decode {
+    ($alpha:ident, $input:ident, $iter:ident, $c:pat => $carry:expr) => ({
+        if $input.len() == 0 {
+            return Ok(Vec::new());
+        }
+
+        let base = $alpha.len() as u16;
+
+        let mut bytes = Vec::with_capacity($input.len());
+        bytes.push(0u8);
+
+        for $c in $input.$iter() {
+            let mut carry = $carry as u16;
+
+            for byte in bytes.iter_mut() {
+                carry += base * *byte as u16;
+                *byte = carry as u8;
+                carry >>= 8;
+            }
+
+            while carry > 0 {
+                bytes.push(carry as u8);
+                carry >>= 8;
+            }
+        }
+
+        let leader = $alpha[0];
+
+        let leaders = $input
+            .$iter()
+            .take($input.len() - 1)
+            .take_while(|byte| *byte == leader)
+            .map(|_| 0);
+
+        bytes.extend(leaders);
+        bytes.reverse();
+        Ok(bytes)
+    })
+}
+
+impl AsciiDecoder {
+    #[inline(always)]
+    pub fn decode(alphabet: &[u8], lookup: [u8; 256], input: &str) -> Result<Vec<u8>, DecodeError> {
+        decode!(alphabet, input, bytes, c => match lookup[c as usize] {
+            0xFF => return Err(DecodeError),
+            index => index
+        })
+    }
+}
+
+impl Utf8Decoder {
+    #[inline(always)]
+    pub fn decode(alphabet: &[char], lookup: HashMap<char, usize>, input: &str) -> Result<Vec<u8>, DecodeError> {
+        decode!(alphabet, input, chars, c => *lookup.get(&c).ok_or(DecodeError)?)
+    }
+}

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -15,7 +15,7 @@ macro_rules! decode {
         let mut big = BigUint::with_capacity(4);
 
         for $c in $input.$iter() {
-            big.add_mul($carry as u32, base);
+            big.mul_add(base, $carry as u32);
         }
 
         let mut bytes = big.into_bytes_be();

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use DecodeError;
 
 pub struct AsciiDecoder;
@@ -57,7 +55,11 @@ impl AsciiDecoder {
 
 impl Utf8Decoder {
     #[inline(always)]
-    pub fn decode(alphabet: &[char], lookup: HashMap<char, usize>, input: &str) -> Result<Vec<u8>, DecodeError> {
-        decode!(alphabet, input, chars, c => *lookup.get(&c).ok_or(DecodeError)?)
+    pub fn decode(alphabet: &[char], input: &str) -> Result<Vec<u8>, DecodeError> {
+        decode!(alphabet, input, chars, c => alphabet.iter()
+                                                    .enumerate()
+                                                    .find(|&(_, ch)| *ch == c)
+                                                    .map(|(i, _)| i)
+                                                    .ok_or(DecodeError)?)
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -16,7 +16,7 @@ macro_rules! encode {
         let mut big = BigUint::from($input);
         let mut out = Vec::with_capacity($input.len());
 
-        loop {
+        'big: loop {
             let mut big_rem = big.rem_div(big_base);
 
             if big.is_zero() {
@@ -25,10 +25,9 @@ macro_rules! encode {
                     big_rem /= base;
 
                     if big_rem == 0 {
-                        break;
+                        break 'big;
                     }
                 }
-                break;
             } else {
                 for _ in 0..big_pow {
                     out.push($alpha[(big_rem % base) as usize]);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,72 +1,52 @@
+use bigint::BigUint;
+
 pub struct AsciiEncoder;
 pub struct Utf8Encoder;
 
 macro_rules! encode {
-    ($alpha:ident, $input:ident, $dig:ty) => ({
+    ($alpha:ident, $input:ident) => ({
         if $input.len() == 0 {
             return String::new();
         }
 
-        let base = $alpha.len() as u16;
+        let base = $alpha.len() as u32;
 
-        let mut digits: Vec<$dig> = Vec::with_capacity($input.len());
-        digits.push(0);
+        let mut big = BigUint::from($input);
+        let mut out = Vec::with_capacity($input.len());
 
-        for c in $input {
-            let mut carry = *c as u16;
-
-            for digit in digits.iter_mut() {
-                carry |= (*digit as u16) << 8;
-                *digit = (carry % base) as $dig;
-                carry /= base;
-            }
-
-            while carry > 0 {
-                digits.push((carry % base) as $dig);
-                carry /= base;
-            }
+        while !big.is_zero() {
+            out.push($alpha[big.rem(base) as usize]);
+            big /= base;
         }
 
         let leaders = $input
             .iter()
             .take($input.len() - 1)
             .take_while(|i| **i == 0)
-            .map(|_| 0);
+            .map(|_| $alpha[0]);
 
-        digits.extend(leaders);
+        out.extend(leaders);
 
-        digits
+        out
     })
 }
 
 impl AsciiEncoder {
     #[inline(always)]
     pub fn encode(alphabet: &[u8], input: &[u8]) -> String {
-        let mut digits = encode!(alphabet, input, u8);
+        let mut out = encode!(alphabet, input);
 
-        digits.reverse();
+        out.reverse();
 
-        for digit in digits.iter_mut() {
-            *digit = alphabet[*digit as usize];
-        }
-
-        String::from_utf8(digits).expect("Alphabet must be ASCII")
+        String::from_utf8(out).expect("Alphabet must be ASCII")
     }
 }
 
 impl Utf8Encoder {
     #[inline(always)]
     pub fn encode(alphabet: &[char], input: &[u8]) -> String {
-        let digits = encode!(alphabet, input, u8);
+        let out = encode!(alphabet, input);
 
-        let encoded = digits
-            .iter()
-            .rev()
-            .map(|digit| alphabet[*digit as usize]);
-
-        let mut result = String::new();
-        result.extend(encoded);
-
-        result
+        out.iter().rev().map(|char| *char).collect()
     }
 }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -14,9 +14,12 @@ macro_rules! encode {
         let mut big = BigUint::from($input);
         let mut out = Vec::with_capacity($input.len());
 
-        while !big.is_zero() {
-            out.push($alpha[big.rem(base) as usize]);
-            big /= base;
+        loop {
+            out.push($alpha[big.rem_div(base) as usize]);
+
+            if big.is_zero() {
+                break;
+            }
         }
 
         let leaders = $input

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,0 +1,94 @@
+pub struct AsciiEncoder;
+pub struct Utf8Encoder;
+
+impl AsciiEncoder {
+    #[inline(always)]
+    pub fn encode(alphabet: &[u8], input: &[u8]) -> String {
+        if input.len() == 0 {
+            return String::new();
+        }
+
+        let base = alphabet.len() as u16;
+
+        let mut digits = Vec::with_capacity(input.len());
+        digits.push(0u8);
+
+        for c in input {
+            let mut carry = *c as u16;
+
+            for digit in digits.iter_mut() {
+                carry |= (*digit as u16) << 8;
+                *digit = (carry % base) as u8;
+                carry /= base;
+            }
+
+            while carry > 0 {
+                digits.push((carry % base) as u8);
+                carry /= base;
+            }
+        }
+
+        let leaders = input
+            .iter()
+            .take(input.len() - 1)
+            .take_while(|i| **i == 0)
+            .map(|_| 0);
+
+        digits.extend(leaders);
+        digits.reverse();
+
+        for digit in digits.iter_mut() {
+            *digit = alphabet[*digit as usize];
+        }
+
+        String::from_utf8(digits).expect("Alphabet must be ASCII")
+    }
+}
+
+impl Utf8Encoder {
+    #[inline(always)]
+    pub fn encode(alphabet: &[char], input: &[u8]) -> String {
+        if input.len() == 0 {
+            return String::new();
+        }
+
+        let base = alphabet.len() as u16;
+
+        let mut digits: Vec<u16> = Vec::with_capacity(input.len());
+
+        digits.push(0);
+
+        for c in input {
+            let mut carry = *c as u16;
+
+            for digit in digits.iter_mut() {
+                carry += *digit << 8;
+                *digit = carry % base;
+                carry /= base;
+            }
+
+            while carry > 0 {
+                digits.push(carry % base);
+                carry /= base;
+            }
+        }
+
+        let leaders = input
+            .iter()
+            .take(input.len() - 1)
+            .take_while(|i| **i == 0)
+            .map(|_| 0);
+
+        digits.extend(leaders);
+
+        let encoded = digits
+            .iter()
+            .rev()
+            .map(|digit| alphabet[*digit as usize]);
+
+        let mut result = String::new();
+        result.extend(encoded);
+
+        result
+    }
+}

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -26,7 +26,7 @@ macro_rules! encode {
             // a factor of 5) reduces the amount of divisions that need to
             // be done on BigUint, delegating the hard work to regular `u32`
             // operations, which are blazing fast.
-            let mut big_rem = big.rem_div(big_base);
+            let mut big_rem = big.div_mod(big_base);
 
             if big.is_zero() {
                 loop {

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -10,15 +10,30 @@ macro_rules! encode {
         }
 
         let base = $alpha.len() as u32;
+        let big_pow = 32 / (32 - base.leading_zeros());
+        let big_base = base.pow(big_pow);
 
         let mut big = BigUint::from($input);
         let mut out = Vec::with_capacity($input.len());
 
         loop {
-            out.push($alpha[big.rem_div(base) as usize]);
+            let mut big_rem = big.rem_div(big_base);
 
             if big.is_zero() {
+                loop {
+                    out.push($alpha[(big_rem % base) as usize]);
+                    big_rem /= base;
+
+                    if big_rem == 0 {
+                        break;
+                    }
+                }
                 break;
+            } else {
+                for _ in 0..big_pow {
+                    out.push($alpha[(big_rem % base) as usize]);
+                    big_rem /= base;
+                }
             }
         }
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -12,7 +12,7 @@ macro_rules! encode {
         let base = $alpha.len() as u32;
 
         // Convert the input byte array to a BigUint
-        let mut big = BigUint::from($input);
+        let mut big = BigUint::from_bytes_be($input);
         let mut out = Vec::with_capacity($input.len());
 
         // Find the highest power of `base` that fits in `u32`

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,40 +1,49 @@
 pub struct AsciiEncoder;
 pub struct Utf8Encoder;
 
-impl AsciiEncoder {
-    #[inline(always)]
-    pub fn encode(alphabet: &[u8], input: &[u8]) -> String {
-        if input.len() == 0 {
+macro_rules! encode {
+    ($alpha:ident, $input:ident, $dig:ty) => ({
+        if $input.len() == 0 {
             return String::new();
         }
 
-        let base = alphabet.len() as u16;
+        let base = $alpha.len() as u16;
 
-        let mut digits = Vec::with_capacity(input.len());
-        digits.push(0u8);
+        let mut digits: Vec<$dig> = Vec::with_capacity($input.len());
+        digits.push(0);
 
-        for c in input {
+        for c in $input {
             let mut carry = *c as u16;
 
             for digit in digits.iter_mut() {
                 carry |= (*digit as u16) << 8;
-                *digit = (carry % base) as u8;
+                *digit = (carry % base) as $dig;
                 carry /= base;
             }
 
             while carry > 0 {
-                digits.push((carry % base) as u8);
+                digits.push((carry % base) as $dig);
                 carry /= base;
             }
         }
 
-        let leaders = input
+        let leaders = $input
             .iter()
-            .take(input.len() - 1)
+            .take($input.len() - 1)
             .take_while(|i| **i == 0)
             .map(|_| 0);
 
         digits.extend(leaders);
+
+        digits
+    })
+}
+
+impl AsciiEncoder {
+    #[inline(always)]
+    pub fn encode(alphabet: &[u8], input: &[u8]) -> String {
+        let mut digits = encode!(alphabet, input, u8);
+
         digits.reverse();
 
         for digit in digits.iter_mut() {
@@ -48,38 +57,7 @@ impl AsciiEncoder {
 impl Utf8Encoder {
     #[inline(always)]
     pub fn encode(alphabet: &[char], input: &[u8]) -> String {
-        if input.len() == 0 {
-            return String::new();
-        }
-
-        let base = alphabet.len() as u16;
-
-        let mut digits: Vec<u16> = Vec::with_capacity(input.len());
-
-        digits.push(0);
-
-        for c in input {
-            let mut carry = *c as u16;
-
-            for digit in digits.iter_mut() {
-                carry += *digit << 8;
-                *digit = carry % base;
-                carry /= base;
-            }
-
-            while carry > 0 {
-                digits.push(carry % base);
-                carry /= base;
-            }
-        }
-
-        let leaders = input
-            .iter()
-            .take(input.len() - 1)
-            .take_while(|i| **i == 0)
-            .map(|_| 0);
-
-        digits.extend(leaders);
+        let digits = encode!(alphabet, input, u8);
 
         let encoded = digits
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,10 @@
 //! }
 //! ```
 
+mod encoder;
 mod alphabet;
 
+pub use encoder::{AsciiEncoder, Utf8Encoder};
 pub use alphabet::{Alphabet, CharLookup};
 
 use std::error::Error;
@@ -47,48 +49,7 @@ impl Error for DecodeError {
 
 /// Encode an input vector using the given alphabet.
 pub fn encode<A: Alphabet>(alphabet: A, input: &[u8]) -> String {
-    if input.len() == 0 {
-        return String::new();
-    }
-
-    let base = alphabet.base() as u16;
-
-    let mut digits: Vec<u16> = Vec::with_capacity(input.len());
-
-    digits.push(0);
-
-    for c in input {
-        let mut carry = *c as u16;
-
-        for digit in digits.iter_mut() {
-            carry += *digit << 8;
-            *digit = carry % base;
-            carry /= base;
-        }
-
-        while carry > 0 {
-            digits.push(carry % base);
-            carry /= base;
-        }
-    }
-
-    let leaders = input
-        .iter()
-        .take(input.len() - 1)
-        .take_while(|i| **i == 0)
-        .map(|_| 0);
-
-    digits.extend(leaders);
-
-    let encoded = digits
-        .iter()
-        .rev()
-        .map(|digit| alphabet.get(*digit as usize));
-
-    let mut result = String::new();
-    result.extend(encoded);
-
-    result
+    alphabet.encode(input)
 }
 
 /// Decode an input vector using the given alphabet.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@
 //! }
 //! ```
 
-mod encoder;
-mod alphabet;
+pub mod encoder;
+pub mod alphabet;
 
 pub use encoder::{AsciiEncoder, Utf8Encoder};
 pub use alphabet::{Alphabet, CharLookup};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@
 //! }
 //! ```
 
+mod bigint;
 pub mod decoder;
 pub mod encoder;
 pub mod alphabet;


### PR DESCRIPTION
This is including #8. This changes the encoding implementation from original CPP algorithm, to using a specialized bigint (that I might want to put into another crate altogether), along with some extra optimizations for remainders.

**edit:** Reworked decoding as well.

Without BigUint:
```
test decode_base16 ... bench:       8,085 ns/iter (+/- 1,712)
test decode_base2  ... bench:      33,235 ns/iter (+/- 6,176)
test decode_base58 ... bench:       5,657 ns/iter (+/- 470)
test encode_base16 ... bench:      64,715 ns/iter (+/- 2,458)
test encode_base2  ... bench:     264,201 ns/iter (+/- 8,627)
test encode_base58 ... bench:      43,918 ns/iter (+/- 1,514)
```

:zap: With BigUint :zap:
```
test decode_base16 ... bench:       1,992 ns/iter (+/- 1,006)
test decode_base2  ... bench:       7,198 ns/iter (+/- 2,138)
test decode_base58 ... bench:       1,472 ns/iter (+/- 389)
test encode_base16 ... bench:       5,780 ns/iter (+/- 761)
test encode_base2  ... bench:      12,770 ns/iter (+/- 483)
test encode_base58 ... bench:       4,605 ns/iter (+/- 519)

```

