### PR TITLE
Set license to MIT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "base-x"
 description = "Encode/decode any base"
 version = "0.2.2"
 authors = ["Alex R. <alexei.rudenko@gmail.com>"]
+license = "MIT"
 license-file = "LICENSE.md"
 readme = "README.md"
 keywords = ["base-x", "base", "convert"]


### PR DESCRIPTION
This way tool for automatic license checking are able to see that the license for this project is a standard MIT license. Otherwise, it is detected as a non-standard license (for example on https://crates.io/crates/base-x). 

Also when `license` is properly set then the special make targets like `cargo-crates-licenses` designed for easier maintenance of FreeBSD Rust ports are producing nice results.