### PR TITLE
Shrink unsafe block

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -108,16 +108,16 @@ impl BigUint {
             *chunk = u32::to_be(*chunk);
         }
 
+        let mut bytes = Vec::with_capacity(len);
         unsafe {
-            let mut bytes = Vec::with_capacity(len);
             bytes.set_len(len);
 
             let chunks_ptr = (self.chunks.as_ptr() as *const u8).offset(skip as isize);
 
             ptr::copy_nonoverlapping(chunks_ptr, bytes.as_mut_ptr(), len);
 
-            bytes
         }
+            bytes
     }
 
     #[inline]


### PR DESCRIPTION
In this function you use the unsafe keyword for some safe expressions. However, I found that only 3 functions are real unsafe operations (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the copy_nonoverlapping()\offset()\set_len() function(these are unsafe functions)

@OrKoN
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 